### PR TITLE
Change rpi-ws2801 source

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "body-parser": "latest",
     "color": "latest",
     "lpd8806-async": "latest",
-    "rpi-ws2801": "latest"
+    "rpi-ws2801": "https://github.com/Trekky12/node-rpi-ws2801/tarball/master"
   },
   "devDependencies": {
     "electron-rebuild": "latest"


### PR DESCRIPTION
With the latest raspberrypi kernel the default SPI speed was changed, so for the WS2801 LEDs the SPI speed must be set explicitly. The updated version of rpi-ws2801 set the SPI speed.

see: raspberrypi/linux#2165.

The fix is available here: https://github.com/Trekky12/node-rpi-ws2801/commit/15f465895ecea2e40f13a369ed068a88f686a6bc